### PR TITLE
Makes en-es switching smarter (fixes issue #211)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.7.0)
     kramdown (1.13.2)
-    libv8 (3.16.14.19-x86_64-linux)
+    libv8 (3.16.14.19)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -150,9 +150,6 @@ DEPENDENCIES
   therubyracer
   tzinfo-data
   wdm (~> 0.1.0)
-
-RUBY VERSION
-   ruby 2.3.3p222
 
 BUNDLED WITH
    1.14.6

--- a/source/javascripts/application.js
+++ b/source/javascripts/application.js
@@ -75,3 +75,19 @@ $(window).scroll(function(){
 $("a[data-label]").on("click", function(){
   ga("send", "event", "clicks", $(this).data('label'))
 })
+
+$(".es-btn").on('click', function() {
+	if (window.location.pathname.split("/")[1]==="es") {
+		window.location.pathname = window.location.pathname;
+	} else {
+		window.location.pathname = "/es"+window.location.pathname
+	}
+});
+
+$(".en-btn").on('click', function() {
+	if (window.location.pathname.split("/")[1]==="es") {
+		window.location.pathname = window.location.pathname.split("/")[2];
+	} else {
+		window.location.pathname = window.location.pathname;
+	}
+});

--- a/source/layouts/application-es.erb
+++ b/source/layouts/application-es.erb
@@ -29,7 +29,7 @@
           <a href="/es/enterprise">Para Empresas</a>
         </nav>
         <nav class="logo-menu es-en">
-          <a href="/es/#">ES</a>/<a href="/index.html">EN</a>
+          <a class="es-btn">ES</a>/<a class="en-btn">EN</a>
         </nav>
         <div class="burger">
           <div class="one"></div>
@@ -52,7 +52,7 @@
               <a href="http://www.meetup.com/Monterrey-Ruby-Meetup/" target="_blank">Ruby Meetup</a>
               <a href="http://www.meetup.com/Docker-Monterrey/" target="_blank">Docker Meetup</a>
               <a href="https://www.meetup.com/iosmty/" target="_blank">iOS Meetup</a>
-              <a href="es/culture#positions">Trabajos</a>
+              <a href="/es/culture#positions">Trabajos</a>
               <a href="https://medium.com/@icalialabs" target="_blank">Blog</a>
             </nav>
             <nav class="list-menu">
@@ -81,12 +81,12 @@
           </div>
           <div class="col-2">
             <h4 class="nav-title">Compañía</h4>
-            <a href="es/culture">Cultura</a>
-            <a href="es/process">Procesos</a>
-            <a href="es/projects">Proyectos</a>
-            <a href="es/team">Familia</a>
-            <a href="es/culture#positions">Trabajos</a>
-            <a href="es/contact">Contacto</a>
+            <a href="/es/culture">Cultura</a>
+            <a href="/es/process">Procesos</a>
+            <a href="/es/projects">Proyectos</a>
+            <a href="/es/team">Familia</a>
+            <a href="/es/culture#positions">Trabajos</a>
+            <a href="/es/contact">Contacto</a>
           </div>
           <div class="col-2">
             <h4 class="nav-title">Social</h4>

--- a/source/layouts/application-light-es.erb
+++ b/source/layouts/application-light-es.erb
@@ -29,7 +29,7 @@
           <a href="/es/enterprise">Para Empresas</a>
         </nav>
         <nav class="logo-menu es-en">
-          <a href="/es/#">ES</a>/<a href="index.html">EN</a>
+          <a class="es-btn">ES</a>/<a class="en-btn">EN</a>
         </nav>
         <div class="burger">
           <div class="one"></div>

--- a/source/layouts/application-light.erb
+++ b/source/layouts/application-light.erb
@@ -29,7 +29,7 @@
           <a href="enterprise">For Enterprise</a>
         </nav>
         <nav class="logo-menu es-en">
-          <a href="/es/index.html">ES</a>/<a href="index.html">EN</a>
+          <a class="es-btn">ES</a>/<a class="en-btn">EN</a>
         </nav>
         <div class="burger">
           <div class="one"></div>

--- a/source/layouts/application.erb
+++ b/source/layouts/application.erb
@@ -29,7 +29,7 @@
           <a href="enterprise">For Enterprise</a>
         </nav>
         <nav class="logo-menu es-en">
-          <a href="/es/index.html">ES</a>/<a href="#">EN</a>
+          <a class="es-btn">ES</a>/<a class="en-btn">EN</a>
         </nav>
         <div class="burger">
           <div class="one"></div>

--- a/source/layouts/project-es.erb
+++ b/source/layouts/project-es.erb
@@ -50,7 +50,7 @@
 	              <a href="http://www.meetup.com/Monterrey-Ruby-Meetup/" target="_blank">Ruby Meetup</a>
 	              <a href="http://www.meetup.com/Docker-Monterrey/" target="_blank">Docker Meetup</a>
 	              <a href="https://www.meetup.com/iosmty/" target="_blank">iOS Meetup</a>
-	              <a href="es/culture#positions">Trabajos</a>
+	              <a href="/es/culture#positions">Trabajos</a>
 	              <a href="https://medium.com/@icalialabs" target="_blank">Blog</a>
 	            </nav>
 	            <nav class="list-menu">

--- a/source/localizable/index.es.html.erb
+++ b/source/localizable/index.es.html.erb
@@ -45,7 +45,7 @@ type: index
     <div class="call-buttons-group red">
       <a href="https://icalialabs.typeform.com/to/z4GH28" class="left">Cotiza Ahora</a>
       <i class="sep"></i>
-      <a href="es/projects" class="right">Nuestro Trabajo</a>
+      <a href="/es/projects" class="right">Nuestro Trabajo</a>
     </div>
   </div>
 </section>
@@ -53,7 +53,7 @@ type: index
   <div class="areas-container">
     <div class="vertical-align" id="areas-info" data-1000="opacity:0;" data-1100="opacity:1;">
       <h2 class="big-title">Lo que hacemos</h2>
-      <a href="es/process" class="action-btn">Nuestro proceso</a>
+      <a href="/es/process" class="action-btn">Nuestro proceso</a>
     </div>
     <article class="area-element" id="ar-1" data-800="top:60%;" data-1000="top:50%;">
       <h2>Diseño de Negocio</h2>
@@ -116,19 +116,19 @@ type: index
       <span class="selected-works-slider-item-num">01</span>
       <h3 class="selected-works-slider-item-client">BanRegio</h3>
       <h2 class="selected-works-slider-item-title">Agilizando todo un banco.</h2>
-      <a href="es/cochi" class="selected-works-slider-item-link">Ver caso de estudio</a>
+      <a href="/es/cochi" class="selected-works-slider-item-link">Ver caso de estudio</a>
     </div>
     <div class="selected-works-slider-item">
       <span class="selected-works-slider-item-num">02</span>
       <h3 class="selected-works-slider-item-client">Printoo</h3>
       <h2 class="selected-works-slider-item-title">Regresando la nostalgia de las fotos impresas.</h2>
-      <a href="es/printoo" class="selected-works-slider-item-link">Ver caso de estudio</a>
+      <a href="/es/printoo" class="selected-works-slider-item-link">Ver caso de estudio</a>
     </div>
     <div class="selected-works-slider-item">
       <span class="selected-works-slider-item-num">03</span>
       <h3 class="selected-works-slider-item-client">Okudoc</h3>
       <h2 class="selected-works-slider-item-title">Ayudando a conectar pacientes y doctores.</h2>
-      <a href="es/okudoc" class="selected-works-slider-item-link">Ver caso de estudio</a>
+      <a href="/es/okudoc" class="selected-works-slider-item-link">Ver caso de estudio</a>
     </div>
   </div>
 </section>
@@ -138,7 +138,7 @@ type: index
   <div class="call-buttons-group red">
     <a href="https://icalialabs.typeform.com/to/z4GH28" data-label="quote landing bottom" class="left">Cotiza Ahora</a>
     <i class="sep"></i>
-    <a href="es/projects" class="right">Nuestro Trabajo</a>
+    <a href="/es/projects" class="right">Nuestro Trabajo</a>
   </div>
 </section>
 <script src="../javascripts/skrollr.js"></script>

--- a/source/stylesheets/_navigation_bar.scss
+++ b/source/stylesheets/_navigation_bar.scss
@@ -160,6 +160,9 @@
       color: $light-color;
       left: initial;
       right: 10%;
+      a{
+      	cursor: pointer;
+      }
     }
 
     a {


### PR DESCRIPTION
Instead of relying on the static "/index" & "/es/index" links on the "ES/EN" switch menu, a function is executed on click in order to redirect to the current path with the adequate language.

This way, if for any reason a user lands on a page other than "index" and tries to switch languages, she will not be annoyed by being redirected to a different page... 